### PR TITLE
fix(windows): restore MSVC builds and sign release artifacts

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -205,24 +205,33 @@ jobs:
       - name: Sign executable
         if: ${{ env.WINDOWS_CERT_PFX != '' && env.WINDOWS_CERT_PASSWORD != '' }}
         run: |
-          # Find signtool.exe (Windows SDK)
-          $signtool = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits" -Recurse -Filter "signtool.exe" | Select-Object -First 1 -ExpandProperty FullName
+          # Prefer the newest x64 SignTool from the installed Windows SDK.
+          $signtool = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits" -Recurse -Filter "signtool.exe" |
+            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
 
           if (-not $signtool) {
             Write-Error "SignTool not found"
             exit 1
           }
 
-          # Sign the executable
           $exePath = "build\windows\x64\runner\Release\vagina.exe"
-          & $signtool sign /f "$env:TEMP\cert.pfx" /p "$env:WINDOWS_CERT_PASSWORD" /t http://timestamp.digicert.com /fd SHA256 /v $exePath
+          & $signtool sign /f "$env:TEMP\cert.pfx" /p "$env:WINDOWS_CERT_PASSWORD" /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /v $exePath
 
           if ($LASTEXITCODE -ne 0) {
             Write-Error "Signing failed with exit code $LASTEXITCODE"
             exit 1
           }
 
-          Write-Host "Successfully signed $exePath"
+          $signature = Get-AuthenticodeSignature -FilePath $exePath
+          if ($signature.Status -eq 'NotSigned' -or -not $signature.SignerCertificate) {
+            Write-Error "Authenticode signature was not embedded in $exePath"
+            exit 1
+          }
+
+          Write-Host "Signed $exePath with certificate $($signature.SignerCertificate.Thumbprint)"
+          Write-Host "Signature status: $($signature.Status)"
         shell: powershell
 
       - name: Cleanup certificate

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -57,6 +57,16 @@ add_subdirectory("runner")
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# permission_handler_windows 0.2.1 still enables MSVC's deprecated /await
+# option. Visual Studio 2026 rejects the resulting <experimental/coroutine>
+# include unless this compatibility definition is set. Keep the workaround
+# scoped to the affected plugin until the upstream issue is released:
+# https://github.com/Baseflow/flutter-permission-handler/issues/1534
+if(TARGET permission_handler_windows_plugin)
+  target_compile_definitions(permission_handler_windows_plugin PRIVATE
+    _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+endif()
+
 
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can


### PR DESCRIPTION
## Summary

- scope the MSVC experimental-coroutine compatibility definition to `permission_handler_windows_plugin`
- use the newest x64 SignTool with SHA-256 RFC 3161 timestamping
- verify that an Authenticode signature is embedded before publishing the signed artifact
- configure `WINDOWS_CERT_PFX` and `WINDOWS_CERT_PASSWORD` repository secrets with a CI-only self-signed code-signing certificate

## Root cause

`permission_handler_windows 0.2.1` still passes `/await`. Visual Studio 2026 / MSVC 14.51 rejects the resulting `<experimental/coroutine>` include with STL1011. The Windows implementation has no newer published version, and this is tracked upstream:

- https://github.com/Baseflow/flutter-permission-handler/issues/1534

The compatibility definition is intentionally attached only to the affected plugin target after generated plugin targets are loaded. It can be removed when upstream publishes a C++20 migration.

## Signing note

The configured certificate has the code-signing EKU and is kept only in encrypted GitHub Actions secrets. It is self-signed, so it proves artifact continuity and exercises the Authenticode pipeline but does not replace a publicly trusted commercial code-signing certificate.

Certificate SHA-256 fingerprint:

`C1:9A:6F:4A:FA:F4:8C:AE:A3:58:A0:1C:7B:4A:0F:1C:2C:EF:70:1F:C6:98:F7:3A:4F:9A:1D:6E:AF:F7:C7:1D`

## Validation

- `git diff --check`
- `flutter analyze --no-fatal-infos`
- `flutter test` (167 tests)
- secret-material scan of the tracked diff

Windows debug/release builds and signed artifact generation are validated by this PR's Windows runner.
