### PR TITLE
Fix Windows CI and sideload packaging

### DIFF
--- a/docs/windows_distribution.md
+++ b/docs/windows_distribution.md
@@ -90,8 +90,9 @@ Requirements:
 - Flutter and Dart matching the project;
 - Visual Studio Windows desktop toolchain;
 - Windows SDK containing MakeAppx and SignTool;
-- the committed package identity matching Partner Center;
-- a publisher PFX only for sideload mode.
+- the committed Store package identity matching Partner Center;
+- a publisher PFX only for sideload mode; its subject becomes the sideload
+  manifest publisher and does not need to match the Partner Center publisher.
 
 Build the payload first:
 
@@ -124,7 +125,7 @@ The packaging script fails when:
 
 - an identity value is blank;
 - the project version cannot become a four-component MSIX version;
-- the PFX is missing, lacks a private key, or has a different publisher subject;
+- the PFX is missing or lacks a private key;
 - the MSIX is not created;
 - manifest identity, publisher, or version differs from the requested values;
 - the OAuth protocol declaration is absent;

--- a/scripts/package_windows_msix.ps1
+++ b/scripts/package_windows_msix.ps1
@@ -57,11 +57,10 @@ function Get-MsixConfigValue {
   return $line.Matches[0].Groups[1].Value
 }
 
-function Assert-CertificatePublisher {
+function Get-SideloadPublisher {
   param(
     [Parameter(Mandatory = $true)][string]$Path,
-    [Parameter(Mandatory = $true)][string]$Password,
-    [Parameter(Mandatory = $true)][string]$ExpectedPublisher
+    [Parameter(Mandatory = $true)][string]$Password
   )
 
   if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
@@ -77,15 +76,10 @@ function Assert-CertificatePublisher {
     [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet
   )
   try {
-    $expectedName = [System.Security.Cryptography.X509Certificates.X500DistinguishedName]::new($ExpectedPublisher)
-    $actualSubject = [Convert]::ToBase64String($certificate.SubjectName.RawData)
-    $expectedSubject = [Convert]::ToBase64String($expectedName.RawData)
-    if ($actualSubject -cne $expectedSubject) {
-      throw "Certificate subject '$($certificate.Subject)' does not exactly match Partner Center Publisher '$ExpectedPublisher'."
-    }
     if (-not $certificate.HasPrivateKey) {
       throw "The sideload certificate does not contain a private key."
     }
+    return $certificate.Subject
   } finally {
     $certificate.Dispose()
   }
@@ -163,13 +157,19 @@ function Assert-MsixContents {
 }
 
 $identityName = Get-MsixConfigValue -Name "identity_name"
-$publisher = Get-MsixConfigValue -Name "publisher"
+$storePublisher = Get-MsixConfigValue -Name "publisher"
 $publisherDisplayName = Get-MsixConfigValue -Name "publisher_display_name"
 $version = Get-MsixVersion
 $outputDirectory = Join-Path "build\windows\msix" $Mode.ToLowerInvariant()
 $outputName = "vagina-$($Mode.ToLowerInvariant())-$version-x64"
 $packagePath = Join-Path $outputDirectory "$outputName.msix"
 New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+
+$publisher = if ($Mode -eq "Store") {
+  $storePublisher
+} else {
+  Get-SideloadPublisher -Path $CertificatePath -Password $CertificatePassword
+}
 
 $arguments = @(
   "run", "msix:create",
@@ -186,7 +186,6 @@ $arguments = @(
 if ($Mode -eq "Store") {
   $arguments += "--store"
 } else {
-  Assert-CertificatePublisher -Path $CertificatePath -Password $CertificatePassword -ExpectedPublisher $publisher
   $arguments += @("--certificate-path", $CertificatePath, "--certificate-password", $CertificatePassword)
 }
 

--- a/windows/runner/non_backup_storage.cpp
+++ b/windows/runner/non_backup_storage.cpp
@@ -1,8 +1,9 @@
 #include "non_backup_storage.h"
 
+#include <windows.h>
+
 #include <appmodel.h>
 #include <shlobj.h>
-#include <windows.h>
 
 #include <cstdlib>
 #include <memory>


### PR DESCRIPTION
$Fixes the existing Windows CI failures on main.\n\n- include `windows.h` before Windows SDK component headers\n- use the sideload certificate subject as the sideload MSIX publisher\n- keep the Partner Center publisher for Store packages\n- document the separate publisher behavior\n\nValidated locally with formatting, analysis, and the full test suite.